### PR TITLE
docs(readme): Remove Greenkeeper and Travis badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Greenkeeper badge](https://badges.greenkeeper.io/misund/passes-wcag.svg)](https://greenkeeper.io/)
-[![Build Status](https://travis-ci.org/misund/passes-wcag.svg?branch=master)](https://travis-ci.org/misund/passes-wcag)
-
 # Passes WCAG
 
 Evaluate whether two colors have sufficient contrast to pass WCAG requirements.


### PR DESCRIPTION
We have moved from Greenkeeper to Dependabot and from Travis to GitHub Actions.