### PR TITLE
docs(readme): Rename master => main

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ yarn build && yarn test
 
 ### Releasing
 This project uses [np](https://github.com/sindresorhus/np).
-1. Make sure your changes are in master
+1. Make sure your changes are in the main branch
 2. Run `yarn release`
 3. Follow the interactive release guide


### PR DESCRIPTION
I changed the name of the main branch from master to main. Now also in the readme.